### PR TITLE
Add drag and drop file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The server will start at the specified address (default is `:8080`).
 ## Knowledge Bases
 
 - Create and list knowledge bases, upload `.txt`/`.md` files, and store chunk embeddings in the vector DB.
-- A simple web UI is available at `/kbs.html` which supports drag-and-drop file uploads that automatically start uploading when a file is dropped.
+- A simple web UI is available at `/kbs.html`, featuring drag-and-drop uploads powered by Dropzone.js that automatically start uploading when a file is dropped.
 
 ### API Endpoints
 

--- a/static/kbs.html
+++ b/static/kbs.html
@@ -5,7 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Knowledge Bases - KB Codex</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/dropzone@5/dist/min/dropzone.min.css" rel="stylesheet" />
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dropzone@5/dist/min/dropzone.min.js"></script>
 </head>
 <body>
   <div id="app">
@@ -33,16 +35,7 @@
           <input type="file" class="form-control" @change="onFileChange" accept=".txt,.md" />
           <button class="btn btn-primary" @click="uploadFile">Upload File</button>
         </div>
-        <div class="mb-3">
-          <div class="border rounded p-3 text-center"
-            :class="{'bg-info bg-opacity-25': isDragging}"
-            @dragenter.prevent="isDragging = true"
-            @dragover.prevent="onDragOver"
-            @dragleave="isDragging = false"
-            @drop.prevent="handleDrop">
-            Drag &amp; drop .txt or .md file here
-          </div>
-        </div>
+        <form id="dropzone" class="dropzone mb-3"></form>
         <h3>Files</h3>
         <ul class="list-group">
           <li v-for="file in files" :key="file" class="list-group-item">{{ file }}</li>
@@ -52,7 +45,7 @@
   </div>
   <script>
     const { createApp } = Vue;
-    createApp({
+    const app = createApp({
       data() {
         return {
           kbs: [],
@@ -60,7 +53,7 @@
           selectedKB: null,
           files: [],
           selectedFile: null,
-          isDragging: false,
+          dropzone: null,
         };
       },
       mounted() {
@@ -83,6 +76,7 @@
         selectKB(kb) {
           this.selectedKB = kb;
           this.fetchFiles();
+          this.$nextTick(() => this.initDropzone());
         },
         async fetchFiles() {
           if (!this.selectedKB) return;
@@ -100,20 +94,26 @@
           this.selectedFile = null;
           this.fetchFiles();
         },
-        onDragOver(event) {
-          event.dataTransfer.dropEffect = 'copy';
-          this.isDragging = true;
-        },
-        async handleDrop(event) {
-          this.isDragging = false;
-          const files = event.dataTransfer.files;
-          if (files && files.length > 0) {
-            this.selectedFile = files[0];
-            await this.uploadFile();
+        initDropzone() {
+          if (this.dropzone) {
+            this.dropzone.destroy();
           }
-        },
+          this.dropzone = new Dropzone('#dropzone', {
+            url: `/api/kbs/${this.selectedKB.id}/files`,
+            paramName: 'file',
+            acceptedFiles: '.txt,.md',
+            maxFiles: 1,
+            init: function() {
+              this.on('success', () => {
+                this.removeAllFiles(true);
+                app.fetchFiles();
+              });
+            }
+         });
+       },
       }
-    }).mount('#app');
+    });
+    app.mount('#app');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add drag-and-drop UI to upload files in `kbs.html`
- document drag-and-drop upload support in README

## Testing
- `go vet ./...` *(fails: forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684e057f74308321818650f008177a1e