### PR TITLE
Split KBDetail into ChatView and FileManagementView

### DIFF
--- a/client/src/__tests__/ChatView.test.jsx
+++ b/client/src/__tests__/ChatView.test.jsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import ChatView from '../components/ChatView';
+
+describe('ChatView', () => {
+  it('starts new chat and renders answer', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ answer: 'hi' }) });
+    render(<ChatView kbID="1" kbName="KB1" />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'Hi?' } });
+    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/kbs/1/ask',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+    await waitFor(() => expect(screen.getByText('hi')).toBeInTheDocument());
+  });
+
+  it('continues chat using history', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ answer: 'hi' }) });
+    render(<ChatView kbID="1" kbName="KB1" />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'Hi?' } });
+    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
+    await waitFor(() => expect(screen.getByText('hi')).toBeInTheDocument());
+
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ answer: 'there' }) });
+    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'How?' } });
+    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
+
+    await waitFor(() => {
+      const body = JSON.parse(fetch.mock.calls.at(-1)[1].body);
+      expect(body.history).toEqual([
+        { role: 'user', content: 'Hi?' },
+        { role: 'assistant', content: 'hi' },
+      ]);
+    });
+    await waitFor(() => expect(screen.getByText('there')).toBeInTheDocument());
+  });
+
+  it('shows answer context', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        answer: 'ans',
+        chunks: [{ file_name: 'f.txt', index: 0, content: 'ctx' }],
+      }),
+    });
+    render(<ChatView kbID="1" kbName="KB1" />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'Q?' } });
+    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
+
+    await waitFor(() => expect(screen.getByText('ans')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /show context/i }));
+    await waitFor(() => expect(screen.getByText('ctx')).toBeInTheDocument());
+  });
+});

--- a/client/src/__tests__/FileManagementView.test.jsx
+++ b/client/src/__tests__/FileManagementView.test.jsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import FileManagementView from '../components/FileManagementView';
+
+let slug;
+let files;
+let rerender;
+const setFiles = vi.fn((f) => {
+  files = f;
+});
+const mockNavigate = vi.fn((path) => {
+  slug = decodeURIComponent(path.split('/').pop());
+  rerender(<FileManagementView kbID="1" slug={slug} files={files} refreshFiles={setFiles} />);
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+describe('FileManagementView', () => {
+  beforeEach(() => {
+    slug = undefined;
+    files = [];
+    rerender = undefined;
+    mockNavigate.mockClear();
+    setFiles.mockClear();
+  });
+
+  it('uploads file', async () => {
+    const utils = render(<FileManagementView kbID="1" slug={slug} files={files} refreshFiles={setFiles} />);
+    rerender = utils.rerender;
+
+    const file = new File(['hello'], 't.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } });
+
+    fetch.mockResolvedValueOnce({ ok: true });
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+    fireEvent.click(screen.getByTestId('upload-btn'));
+
+    await waitFor(() => {
+      const call = fetch.mock.calls.find(c => c[0] === '/api/kbs/1/files' && c[1]?.method === 'POST');
+      expect(call).toBeDefined();
+      expect(call[1].body).toBeInstanceOf(FormData);
+      expect(call[1].body.get('file')).toBe(file);
+    });
+  });
+
+  it('opens file viewer when clicking file', async () => {
+    files = [{ slug: 't.txt', name: 't.txt' }];
+    const utils = render(<FileManagementView kbID="1" slug={slug} files={files} refreshFiles={setFiles} />);
+    rerender = utils.rerender;
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('content'),
+    });
+
+    fireEvent.click(screen.getByText('t.txt'));
+
+    await waitFor(() => expect(screen.getByText('content')).toBeInTheDocument());
+  });
+});

--- a/client/src/__tests__/KBDetail.test.jsx
+++ b/client/src/__tests__/KBDetail.test.jsx
@@ -34,75 +34,18 @@ describe('KBDetail', () => {
     const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
     fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } });
 
-    fetch
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ slug: 'test.txt', name: 'test.txt' }]) });
+    fetch.mockResolvedValueOnce({ ok: true });
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
 
     fireEvent.click(screen.getByTestId('upload-btn'));
 
-    await waitFor(() => {
-      const call = fetch.mock.calls.find(c => c[0] === '/api/kbs/1/files' && c[1]?.method === 'POST');
-      expect(call).toBeDefined();
-      expect(call[1].body).toBeInstanceOf(FormData);
-      expect(call[1].body.get('file')).toBe(file);
-    });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/kbs/1/files', expect.objectContaining({ method: 'POST' })));
   });
 
-  it('uploads PDF file', async () => {
+  it('allows chatting', async () => {
     fetch
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ id: 1, name: 'KB1' }]) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
-
-    const utils = render(<KBDetail onLogout={() => {}} />);
-    rerender = utils.rerender;
-
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
-
-    const pdfFile = new File(['%PDF-1.1'], 'test.pdf', { type: 'application/pdf' });
-    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [pdfFile] } });
-
-    fetch
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ slug: 'test.pdf', name: 'test.pdf' }]) });
-
-    fireEvent.click(screen.getByTestId('upload-btn'));
-
-    await waitFor(() => {
-      const call = fetch.mock.calls.find(c => c[0] === '/api/kbs/1/files' && c[1]?.method === 'POST');
-      expect(call).toBeDefined();
-      expect(call[1].body).toBeInstanceOf(FormData);
-      expect(call[1].body.get('file')).toBe(pdfFile);
-    });
-  });
-
-  it('starts new chat and renders answer', async () => {
-    fetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ id: 1, name: 'KB1' }]) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
-
-    const utils = render(<KBDetail onLogout={() => {}} />);
-    rerender = utils.rerender;
-
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
-
-    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ answer: 'hi' }) });
-
-    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'Hi?' } });
-    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
-
-    await waitFor(() =>
-      expect(fetch).toHaveBeenCalledWith(
-        '/api/kbs/1/ask',
-        expect.objectContaining({ method: 'POST', body: JSON.stringify({ question: 'Hi?', history: [] }) })
-      )
-    );
-    await waitFor(() => expect(screen.getByText('hi')).toBeInTheDocument());
-  });
-
-  it('continues existing chat using history', async () => {
-    fetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ id: 1, name: 'KB1' }]) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ slug: 't.txt', name: 't.txt' }]) });
 
     const utils = render(<KBDetail onLogout={() => {}} />);
     rerender = utils.rerender;
@@ -114,21 +57,9 @@ describe('KBDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: /ask/i }));
     await waitFor(() => expect(screen.getByText('hi')).toBeInTheDocument());
 
-    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ answer: 'there' }) });
-    fireEvent.change(screen.getByRole('textbox', { name: /your question/i }), { target: { value: 'How?' } });
-    fireEvent.click(screen.getByRole('button', { name: /ask/i }));
-
-    await waitFor(() => {
-      const body = JSON.parse(fetch.mock.calls.at(-1)[1].body);
-      expect(body.history).toEqual([
-        { role: 'user', content: 'Hi?' },
-        { role: 'assistant', content: 'hi' },
-      ]);
-    });
-    await waitFor(() => expect(screen.getByText('there')).toBeInTheDocument());
   });
 
-  it('opens file viewer when clicking file', async () => {
+  it('lists files and opens them', async () => {
     fetch
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ id: 1, name: 'KB1' }]) })
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ slug: 't.txt', name: 't.txt' }]) });
@@ -145,7 +76,6 @@ describe('KBDetail', () => {
     });
 
     fireEvent.click(screen.getByText('t.txt'));
-
     await waitFor(() => expect(screen.getByText('content')).toBeInTheDocument());
   });
 });

--- a/client/src/components/ChatView.jsx
+++ b/client/src/components/ChatView.jsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from "react";
+import { marked } from "marked";
+
+export default function ChatView({ kbID, kbName }) {
+  const [question, setQuestion] = useState("");
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState({});
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current && inputRef.current.focus();
+  }, []);
+  useEffect(() => {
+    if (!loading) {
+      inputRef.current && inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const askQuestion = async () => {
+    if (!question || loading) return;
+    setLoading(true);
+    const history = messages.map((m) => ({ role: m.role, content: m.content }));
+    const resp = await fetch(`/api/kbs/${kbID}/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question, history }),
+    });
+    const data = await resp.json();
+    const ans = data.answer || "No answer";
+    setMessages([
+      ...messages,
+      { role: "user", content: question },
+      { role: "assistant", content: ans, context: data.chunks || [] },
+    ]);
+    setQuestion("");
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <h2 className="mb-3">Chat with {kbName}</h2>
+      <div className="mb-3" style={{ height: "60vh", overflowY: "auto" }}>
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={
+              "d-flex mb-2 " +
+              (m.role === "user" ? "justify-content-end" : "justify-content-start")
+            }
+          >
+            <div
+              className={
+                "p-2 rounded-3 " +
+                (m.role === "user" ? "bg-primary text-white" : "bg-light")
+              }
+              style={{ maxWidth: "80%" }}
+            >
+              {m.role === "assistant" ? (
+                <div>
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: marked.parse(m.content),
+                    }}
+                  ></span>
+                  {m.context && m.context.length > 0 && (
+                    <>
+                      <button
+                        className="btn btn-sm btn-link mt-2"
+                        type="button"
+                        onClick={() => setExpanded((e) => ({ ...e, [i]: !e[i] }))}
+                      >
+                        <i className="bi bi-info-circle"></i>{" "}
+                        {expanded[i] ? "Hide context" : "Show context"}
+                      </button>
+                      {expanded[i] && (
+                        <ul className="list-group mt-2">
+                          {m.context.map((c) => (
+                            <li
+                              key={c.file_name + "-" + c.index}
+                              className="list-group-item"
+                            >
+                              <strong>
+                                {c.file_name} [{c.index}]
+                              </strong>
+                              <pre className="mt-2 mb-0">{c.content}</pre>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </>
+                  )}
+                </div>
+              ) : (
+                m.content
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="input-group mb-3">
+        <input
+          aria-label="Your question"
+          ref={inputRef}
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          type="text"
+          className="form-control"
+          placeholder="Type your question"
+          onKeyUp={(e) => (e.key === "Enter" ? askQuestion() : null)}
+          disabled={loading}
+        />
+        <button className="btn btn-primary" onClick={askQuestion} disabled={loading}>
+          {loading ? (
+            <span className="spinner-border spinner-border-sm"></span>
+          ) : (
+            "Ask"
+          )}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/client/src/components/FileManagementView.jsx
+++ b/client/src/components/FileManagementView.jsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import FileViewer from "./FileViewer";
+
+export default function FileManagementView({ kbID, slug, files, refreshFiles }) {
+  const navigate = useNavigate();
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [viewFile, setViewFile] = useState(null);
+
+  const fetchFiles = async () => {
+    const res = await fetch(`/api/kbs/${kbID}/files`);
+    const list = await res.json();
+    refreshFiles(list);
+  };
+
+
+  const fetchFile = async (file) => {
+    const res = await fetch(
+      `/api/kbs/${kbID}/files/${encodeURIComponent(file.slug)}`,
+    );
+    if (res.ok) {
+      const mimeType = res.headers.get("Content-Type") || "";
+      let content;
+      if (mimeType.startsWith("application/pdf")) {
+        content = await res.arrayBuffer();
+      } else {
+        content = await res.text();
+      }
+      setViewFile({ name: file.name, content, mimeType });
+    }
+  };
+
+  useEffect(() => {
+    if (!slug) {
+      setViewFile(null);
+      return;
+    }
+    if (files.length > 0) {
+      const f = files.find((fi) => fi.slug === slug) || { slug, name: slug };
+      fetchFile(f);
+    }
+  }, [slug, files]);
+
+  const uploadFile = async () => {
+    if (!selectedFile) return;
+    const form = new FormData();
+    form.append("file", selectedFile);
+    await fetch(`/api/kbs/${kbID}/files`, { method: "POST", body: form });
+    setSelectedFile(null);
+    fetchFiles();
+  };
+
+  const openFile = (file) => {
+    if (!file) return;
+    if (slug !== file.slug) {
+      navigate(`/kbs/${kbID}/files/${encodeURIComponent(file.slug)}`);
+    } else {
+      fetchFile(file);
+    }
+  };
+
+  return (
+    <>
+      {viewFile && (
+        <FileViewer
+          file={viewFile}
+          onClose={() => {
+            setViewFile(null);
+            navigate(`/kbs/${kbID}`);
+          }}
+        />
+      )}
+      <h4>Files</h4>
+      <ul className="list-group mb-3">
+        {(files || []).map((file) => (
+          <li
+            key={file.slug}
+            className="list-group-item list-group-item-action"
+            onClick={() => openFile(file)}
+            role="button"
+          >
+            {file.name}
+          </li>
+        ))}
+      </ul>
+      <div className="input-group">
+        <input
+          data-testid="file-input"
+          type="file"
+          className="form-control"
+          accept=".txt,.md,.pdf"
+          onChange={(e) => setSelectedFile(e.target.files[0])}
+        />
+        <button data-testid="upload-btn" className="btn btn-primary" onClick={uploadFile}>
+          Upload
+        </button>
+      </div>
+    </>
+  );
+}

--- a/client/src/components/KBDetail.jsx
+++ b/client/src/components/KBDetail.jsx
@@ -1,249 +1,43 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { marked } from "marked";
 import KBLayout from "./KBLayout";
-import FileViewer from "./FileViewer";
+import ChatView from "./ChatView";
+import FileManagementView from "./FileManagementView";
 
-function KBDetail({ onLogout }) {
+export default function KBDetail({ onLogout }) {
   const { kbID, slug } = useParams();
   const navigate = useNavigate();
   const [kbName, setKbName] = useState("");
   const [files, setFiles] = useState([]);
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [viewFile, setViewFile] = useState(null);
-  const [question, setQuestion] = useState("");
-  const [messages, setMessages] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const inputRef = React.useRef(null);
-  const [expanded, setExpanded] = useState({});
-
-  const fetchMeta = async () => {
-    const res = await fetch("/api/kbs");
-    const list = await res.json();
-    const kb = list.find((k) => String(k.id) === kbID);
-    setKbName(kb ? kb.name : "");
-  };
-
-  const fetchFiles = async () => {
-    const res = await fetch(`/api/kbs/${kbID}/files`);
-    setFiles(await res.json());
-  };
 
   useEffect(() => {
+    const fetchMeta = async () => {
+      const res = await fetch("/api/kbs");
+      const list = await res.json();
+      const kb = list.find((k) => String(k.id) === kbID);
+      setKbName(kb ? kb.name : "");
+    };
+    const fetchFiles = async () => {
+      const res = await fetch(`/api/kbs/${kbID}/files`);
+      setFiles(await res.json());
+    };
     fetchMeta();
     fetchFiles();
   }, [kbID]);
 
-  useEffect(() => {
-    if (!slug) {
-      setViewFile(null);
-      return;
-    }
-    if (files.length > 0) {
-      const f = files.find((fi) => fi.slug === slug) || { slug, name: slug };
-      fetchFile(f);
-    }
-  }, [slug, files]);
-
-  useEffect(() => {
-    inputRef.current && inputRef.current.focus();
-  }, []);
-
-  useEffect(() => {
-    if (!loading) {
-      inputRef.current && inputRef.current.focus();
-    }
-  }, [loading]);
-
-  const uploadFile = async () => {
-    if (!selectedFile) return;
-    const form = new FormData();
-    form.append("file", selectedFile);
-    await fetch(`/api/kbs/${kbID}/files`, { method: "POST", body: form });
-    setSelectedFile(null);
-    fetchFiles();
-  };
-
-  const fetchFile = async (file) => {
-    const res = await fetch(
-      `/api/kbs/${kbID}/files/${encodeURIComponent(file.slug)}`,
-    );
-    if (res.ok) {
-      const mimeType = res.headers.get("Content-Type") || "";
-      let content;
-      if (mimeType.startsWith("application/pdf")) {
-        content = await res.arrayBuffer();
-      } else {
-        content = await res.text();
-      }
-      setViewFile({ name: file.name, content, mimeType });
-    }
-  };
-
-  const openFile = (file) => {
-    if (!file) return;
-    if (slug !== file.slug) {
-      navigate(`/kbs/${kbID}/files/${encodeURIComponent(file.slug)}`);
-    } else {
-      fetchFile(file);
-    }
-  };
-
-  const askQuestion = async () => {
-    if (!question || loading) return;
-    setLoading(true);
-    const history = messages.map((m) => ({ role: m.role, content: m.content }));
-    const resp = await fetch(`/api/kbs/${kbID}/ask`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ question, history }),
-    });
-    const data = await resp.json();
-    const ans = data.answer || "No answer";
-    setMessages([
-      ...messages,
-      { role: "user", content: question },
-      { role: "assistant", content: ans, context: data.chunks || [] },
-    ]);
-    setQuestion("");
-    setLoading(false);
-    inputRef.current && inputRef.current.focus();
-  };
-
   return (
     <KBLayout onLogout={onLogout}>
-      {viewFile && (
-        <FileViewer
-          file={viewFile}
-          onClose={() => {
-            setViewFile(null);
-            navigate(`/kbs/${kbID}`);
-          }}
-        />
-      )}
       <button className="btn btn-link mb-3" onClick={() => navigate("/kbs")}>
         <i className="bi bi-arrow-left"></i> Back to list
       </button>
       <div className="row">
         <div className="col-md-8 col-lg-9 order-2 order-md-1">
-          <h2 className="mb-3">Chat with {kbName}</h2>
-          <div className="mb-3" style={{ height: "60vh", overflowY: "auto" }}>
-            {messages.map((m, i) => (
-              <div
-                key={i}
-                className={
-                  "d-flex mb-2 " +
-                  (m.role === "user"
-                    ? "justify-content-end"
-                    : "justify-content-start")
-                }
-              >
-                <div
-                  className={
-                    "p-2 rounded-3 " +
-                    (m.role === "user" ? "bg-primary text-white" : "bg-light")
-                  }
-                  style={{ maxWidth: "80%" }}
-                >
-                  {m.role === "assistant" ? (
-                    <div>
-                      <span
-                        dangerouslySetInnerHTML={{
-                          __html: marked.parse(m.content),
-                        }}
-                      ></span>
-                      {m.context && m.context.length > 0 && (
-                        <>
-                          <button
-                            className="btn btn-sm btn-link mt-2"
-                            type="button"
-                            onClick={() =>
-                              setExpanded((e) => ({ ...e, [i]: !e[i] }))
-                            }
-                          >
-                            <i className="bi bi-info-circle"></i>{" "}
-                            {expanded[i] ? "Hide context" : "Show context"}
-                          </button>
-                          {expanded[i] && (
-                            <ul className="list-group mt-2">
-                              {m.context.map((c) => (
-                                <li
-                                  key={c.file_name + "-" + c.index}
-                                  className="list-group-item"
-                                >
-                                  <strong>
-                                    {c.file_name} [{c.index}]
-                                  </strong>
-                                  <pre className="mt-2 mb-0">{c.content}</pre>
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </>
-                      )}
-                    </div>
-                  ) : (
-                    m.content
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="input-group mb-3">
-            <input
-              aria-label="Your question"
-              ref={inputRef}
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              type="text"
-              className="form-control"
-              placeholder="Type your question"
-              onKeyUp={(e) => (e.key === "Enter" ? askQuestion() : null)}
-              disabled={loading}
-            />
-            <button
-              className="btn btn-primary"
-              onClick={askQuestion}
-              disabled={loading}
-            >
-              {loading ? (
-                <span className="spinner-border spinner-border-sm"></span>
-              ) : (
-                "Ask"
-              )}
-            </button>
-          </div>
+          <ChatView kbID={kbID} kbName={kbName} />
         </div>
         <div className="col-md-4 col-lg-3 order-1 order-md-2 mb-4">
-          <h4>Files</h4>
-          <ul className="list-group mb-3">
-            {(files || []).map((file) => (
-              <li
-                key={file.slug}
-                className="list-group-item list-group-item-action"
-                onClick={() => openFile(file)}
-                role="button"
-              >
-                {file.name}
-              </li>
-            ))}
-          </ul>
-          <div className="input-group">
-            <input
-              data-testid="file-input"
-              type="file"
-              className="form-control"
-              accept=".txt,.md,.pdf"
-              onChange={(e) => setSelectedFile(e.target.files[0])}
-            />
-            <button data-testid="upload-btn" className="btn btn-primary" onClick={uploadFile}>
-              Upload
-            </button>
-          </div>
+          <FileManagementView kbID={kbID} slug={slug} files={files} refreshFiles={setFiles} />
         </div>
       </div>
     </KBLayout>
   );
 }
-
-export default KBDetail;


### PR DESCRIPTION
## Summary
- create new `ChatView` and `FileManagementView` components
- refactor `KBDetail` to use the new views
- add unit tests for the new components
- keep KBDetail tests as smoke tests
- verify uploaded file contents in tests and split chat/file tests

## Testing
- `npm test --silent`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68722d6cce648321838e360de5c77313